### PR TITLE
#11-TS : nginx port 8080 — compatibilité Docker rootless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Nginx dev : port hôte changé de 80 à 8080 (issue #11) — compatibilité Docker rootless (`ip_unprivileged_port_start=1024`)
+
 ### Added
 - Stack backend initialisée (issue #6)
   - Symfony 7.4.8 LTS (`symfony/skeleton`)
@@ -11,7 +14,7 @@
   - symfony/messenger (transport RabbitMQ via `MESSENGER_TRANSPORT_DSN`)
   - symfony/mailer (Mailpit en dev via `MAILER_DSN`)
   - nelmio/cors-bundle 2.6.1
-  - API disponible sur `http://localhost/api`, Swagger UI sur `http://localhost/api/docs`
+  - API disponible sur `http://localhost:8080/api`, Swagger UI sur `http://localhost:8080/api/docs`
   - Correction Dockerfile PHP : `opcache` retiré de `docker-php-ext-install` (compilé statiquement en PHP 8.5), `xdebug.ini` renommé pour ne pas écraser le fichier généré par `docker-php-ext-enable`
 
 - Infrastructure Docker complète (issue #3, PR #4)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ docker compose logs -f        # Suivre les logs
 
 | Service | URL |
 |---|---|
-| API Backend | http://localhost |
+| API Backend | http://localhost:8080 |
 | Frontend Vite | http://localhost:5173 |
 | RabbitMQ Management | http://localhost:15672 |
 | Mailpit | http://localhost:8025 |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     build:
       context: ./devops/docker/dev/nginx
     ports:
-      - "80:80"
+      - "8080:80"
     volumes:
       - ./backend:/var/www/html
     depends_on:


### PR DESCRIPTION
## Contexte

Issue #11 (QA finding) : le conteneur nginx ne pouvait pas démarrer en mode Docker rootless car le port 80 est un port privilégié (`ip_unprivileged_port_start=1024`).

## Solution retenue

Port hôte nginx changé de `80` à `8080` dans `docker-compose.yml`. Le port interne du conteneur reste 80 — seul le mapping hôte change. Aucune modification de la configuration nginx ni de Symfony.

## Modifications

- `docker-compose.yml` : `"80:80"` → `"8080:80"` (service nginx)
- `CLAUDE.md` : URL API Backend → `http://localhost:8080`
- `CHANGELOG.md` : URLs corrigées + entrée `Changed`

## Validation

- `docker compose up -d nginx` → conteneur démarré sans erreur ✅
- `curl http://localhost:8080/api` → `200 OK` ✅
- Port interne nginx inchangé (80) ✅

## Notes

- L'environnement de production (`docker-compose.prod.yml`) n'est pas concerné — nginx y est exposé sur le port 80 via un reverse proxy ou une configuration système adaptée.
- Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)