### PR TITLE
#13-TS : Makefile — raccourcis pour les commandes du projet

### DIFF
--- a/.claude/commands/devops.md
+++ b/.claude/commands/devops.md
@@ -43,10 +43,11 @@ devops/docker/prod/         # Dockerfiles prod
 ## Commandes utiles
 
 ```bash
-docker compose up -d
-docker compose down
-docker compose logs -f
-docker compose exec php bin/console doctrine:migrations:migrate
+make up        # Démarrer tous les services
+make down      # Arrêter tous les services
+make logs      # Suivre les logs
+make migrate   # Exécuter les migrations Doctrine
+make build     # Rebuild les images sans cache
 ```
 
 ## Règles d'honnêteté
@@ -69,6 +70,7 @@ docker compose exec php bin/console doctrine:migrations:migrate
 - [ ] Toutes les tâches sont implémentées et testées en environnement dev
 - [ ] La revue Security & Code Reviewer a été obtenue (feu vert explicite)
 - [ ] Aucun secret ni port sensible n'est exposé
+- [ ] Si impact sur commandes ou config utilisateur : feu vert Documentaliste obtenu avant merge
 
 Si une étape échoue, tu ne passes pas à la suivante et tu documentes l'erreur avant d'intervenir.
 
@@ -79,6 +81,11 @@ Si une étape échoue, tu ne passes pas à la suivante et tu documentes l'erreur
 > ⏸ **Gate TSI1 — validation requise**
 > Livraison : TS rédigée avec liste de tâches complète
 > Prochain : implémentation (DevOps) — en attente de ton feu vert
+
+**Pour une TS-Infra (après Gate TSI2 — prêt pour merge) :**
+
+Si impact sur commandes ou config utilisateur : attendre le feu vert Documentaliste avant de merger.
+Sinon : merger directement.
 
 Le déploiement (fin de flux US ou TS-Technique) ne nécessite pas de gate — il est déclenché après le Gate 5 / Gate TS3 que tu as déjà validé.
 

--- a/.claude/commands/documentaliste.md
+++ b/.claude/commands/documentaliste.md
@@ -14,7 +14,8 @@ Tu transformes le code et les specs existants en documentation lisible et mainte
 - Documenter les endpoints API (à partir des annotations API Platform et du contrat Architecte)
 - Rédiger les guides techniques pour les agents développeurs (`docs/dev/`)
 - Rédiger les guides utilisateur si nécessaire (`docs/user/`)
-- Mettre à jour le CLAUDE.md si l'architecture ou les conventions évoluent
+- Mettre à jour `CLAUDE.md` si l'architecture ou les conventions évoluent
+- Mettre à jour `README.md` si les commandes, les URLs ou le setup changent
 - Maintenir un changelog (`CHANGELOG.md`)
 
 ## Périmètre strict
@@ -34,12 +35,13 @@ Tu transformes le code et les specs existants en documentation lisible et mainte
 ## Structure de la documentation
 
 ```
+README.md           # Point d'entrée public (commandes, URLs, setup)
+CHANGELOG.md        # Historique des changements
 docs/
 ├── architecture/   # Contrats API et modèles (produits par l'Architecte)
 ├── design/         # Specs UI/UX (produites par l'UI/UX Designer)
 ├── dev/            # Guides pour les développeurs
 └── user/           # Guides utilisateur
-CHANGELOG.md
 ```
 
 ## Règles d'honnêteté
@@ -52,12 +54,15 @@ CHANGELOG.md
 
 **Pour une US :**
 - [ ] Chaque endpoint de la feature est documenté avec ses paramètres et exemples de réponse
-- [ ] Le CHANGELOG.md est mis à jour
+- [ ] `README.md` vérifié et mis à jour si les commandes, URLs ou prérequis ont changé
+- [ ] `CLAUDE.md` vérifié et mis à jour si l'architecture ou les conventions ont évolué
+- [ ] `CHANGELOG.md` mis à jour
 - [ ] Aucune incohérence n'a été détectée entre le code et les specs (ou une issue est ouverte si c'est le cas)
 
 **Pour une TS-Infra (si impact sur commandes ou config utilisateur) :**
-- [ ] CLAUDE.md mis à jour (commandes, URLs, conventions impactées)
-- [ ] CHANGELOG.md mis à jour
+- [ ] `README.md` mis à jour (commandes, URLs, prérequis)
+- [ ] `CLAUDE.md` mis à jour (commandes, conventions impactées)
+- [ ] `CHANGELOG.md` mis à jour
 - [ ] Aucune incohérence entre la documentation et l'implémentation
 
 Tu ne documentes que ce qui est implémenté et validé. Documenter du code non validé est interdit.

--- a/.claude/commands/documentaliste.md
+++ b/.claude/commands/documentaliste.md
@@ -3,11 +3,11 @@ description: Agent Documentaliste — rédige la documentation API, technique et
 model: claude-haiku-4-5-20251001
 ---
 
-Tu es le Documentaliste du projet money-manager. Tu interviens après le QA, sur des features validées et stables.
+Tu es le Documentaliste du projet money-manager. Tu interviens après le QA (flux US et TS-Technique) ou après le Security & Code Reviewer (flux TS-Infra avec impact sur commandes ou config utilisateur), sur du code validé et stable.
 
 ## Rôle
 
-Tu transformes le code et les specs existants en documentation lisible et maintenue. Tu ne documentes jamais du code non encore validé par le QA.
+Tu transformes le code et les specs existants en documentation lisible et maintenue. Tu ne documentes jamais du code non encore validé.
 
 ## Responsabilités
 
@@ -19,7 +19,7 @@ Tu transformes le code et les specs existants en documentation lisible et mainte
 
 ## Périmètre strict
 
-- Tu ne documentes que ce qui est implémenté et validé
+- Tu ne documentes que ce qui est implémenté et validé (par le QA ou le Security & Code Reviewer selon le flux)
 - Tu ne modifies pas le code — uniquement la documentation
 - Si tu identifies une incohérence entre le code et les specs, tu ouvres une issue GitHub
 
@@ -50,12 +50,27 @@ CHANGELOG.md
 
 ## Définition de "terminé"
 
-La documentation est terminée quand :
+**Pour une US :**
 - [ ] Chaque endpoint de la feature est documenté avec ses paramètres et exemples de réponse
 - [ ] Le CHANGELOG.md est mis à jour
 - [ ] Aucune incohérence n'a été détectée entre le code et les specs (ou une issue est ouverte si c'est le cas)
 
-Tu ne documentes que ce qui est implémenté et validé par le QA. Documenter du code non validé est interdit.
+**Pour une TS-Infra (si impact sur commandes ou config utilisateur) :**
+- [ ] CLAUDE.md mis à jour (commandes, URLs, conventions impactées)
+- [ ] CHANGELOG.md mis à jour
+- [ ] Aucune incohérence entre la documentation et l'implémentation
+
+Tu ne documentes que ce qui est implémenté et validé. Documenter du code non validé est interdit.
+
+## Passation
+
+**Pour une US :**
+
+> Feu vert Documentaliste — documentation à jour, CHANGELOG mis à jour
+
+**Pour une TS-Infra :**
+
+> Feu vert Documentaliste — CLAUDE.md et CHANGELOG mis à jour, prêt pour merge
 
 ## Contexte projet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 - Nginx dev : port hôte changé de 80 à 8080 (issue #11) — compatibilité Docker rootless (`ip_unprivileged_port_start=1024`)
+- Commandes CLAUDE.md restructurées autour des cibles `make` (issue #13)
+- Flux TS-Infra : ajout d'une étape Documentaliste conditionnelle après Gate TSI2 (si impact sur commandes ou config utilisateur)
+
+### Added
+- Makefile à la racine avec raccourcis pour Docker, Symfony, Composer, npm et tests (issue #13) — `make help` liste toutes les cibles
 
 ### Added
 - Stack backend initialisée (issue #6)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,20 +28,25 @@ docker-compose.prod.yml     # Production
 
 ## Commandes
 
+> Un `Makefile` est disponible à la racine — `make help` liste toutes les cibles disponibles.
+
 ### Setup initial
 
 ```bash
-cp .env.example .env                  # Copier et renseigner les variables
-bash devops/generate-jwt-keys.sh      # Générer les clés JWT RS256
-docker compose up -d                  # Démarrer tous les services
+make setup   # Copie .env.example → .env (si absent), génère les clés JWT, démarre Docker
 ```
+
+Si `.env` n'existe pas, `make setup` le crée et s'arrête — renseigne les variables, puis relance.
 
 ### Docker (dev)
 
 ```bash
-docker compose up -d          # Démarrer tous les services
-docker compose down           # Arrêter tous les services
-docker compose logs -f        # Suivre les logs
+make up       # Démarrer tous les services
+make down     # Arrêter tous les services
+make logs     # Suivre les logs (Ctrl+C pour quitter)
+make restart  # Redémarrer tous les services
+make ps       # État des conteneurs
+make build    # Rebuild les images sans cache
 ```
 
 ### Services dev
@@ -59,37 +64,38 @@ docker compose logs -f        # Suivre les logs
 ### Backend (Symfony)
 
 ```bash
-docker compose exec php composer install
-docker compose exec php bin/console cache:clear
-docker compose exec php bin/console doctrine:migrations:migrate
-docker compose exec php bin/console doctrine:migrations:diff   # Générer une migration depuis les changements d'entités
+make install                          # Installer les dépendances Composer
+make cc                               # Vider le cache Symfony
+make migrate                          # Exécuter les migrations Doctrine
+make diff                             # Générer une migration depuis les entités
+make sf c="about"                     # Commande console libre
+make require p="vendor/package"       # Ajouter une dépendance Composer
+make require-dev p="vendor/package"   # Ajouter une dépendance dev
 ```
 
 ### Frontend
 
 ```bash
-cd frontend
-npm install
-npm run dev        # Démarrer le serveur de dev Vite
-npm run build      # Build de production
-npm run lint       # ESLint
+make npm-install                  # Installer les dépendances npm (conteneur)
+make lint                         # Lancer ESLint
+make npm-add p="package"          # Ajouter une dépendance npm
+make npm-add-dev p="package"      # Ajouter une dépendance npm dev
 ```
 
 ### Tests
 
 ```bash
-# Backend
-docker compose exec php bin/phpunit
-docker compose exec php bin/phpunit tests/Unit/MyTest.php   # Fichier de test unique
+make test           # Tous les tests (backend + frontend)
+make test-back      # PHPUnit (backend)
+make test-front     # Vitest (frontend, exécution unique)
+make test-e2e       # Playwright (E2E)
+```
 
-# Frontend — unitaires/composants
-cd frontend
-npm run test              # Vitest (mode watch)
-npm run test -- --run     # Vitest (exécution unique)
+Tests ciblés :
 
-# Frontend — E2E
-npm run test:e2e          # Playwright
-npm run test:e2e -- --grep "nom du test"   # Test E2E unique
+```bash
+docker compose exec php bin/phpunit tests/Unit/MyTest.php              # PHPUnit fichier unique
+docker compose exec node npm run test:e2e -- --grep "nom du test"      # Playwright test unique
 ```
 
 ## Architecture
@@ -136,7 +142,7 @@ Chaque ⏸ gate est un point d'arrêt — aucun agent ne démarre sans feu vert 
 
 **Flux TS-Technique :** Architecte → ⏸TS1 → Backend/Frontend Dev → Security Reviewer → ⏸TS2 → QA → ⏸TS3 → DevOps
 
-**Flux TS-Infra :** DevOps → ⏸TSI1 → DevOps → Security Reviewer → ⏸TSI2 → merge
+**Flux TS-Infra :** DevOps → ⏸TSI1 → DevOps → Security Reviewer → ⏸TSI2 → Documentaliste *(si impact sur commandes ou config utilisateur)* → merge
 
 **Flux TS-Transverse :** initiateur choisi par le PO, puis flux TS-Technique.
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,113 @@
+.DEFAULT_GOAL := help
+
+# ── Docker ────────────────────────────────────────────────────────────────────
+
+up: ## Démarrer tous les services Docker
+	docker compose up -d
+
+down: ## Arrêter tous les services Docker
+	docker compose down
+
+restart: ## Redémarrer tous les services Docker
+	docker compose restart
+
+logs: ## Suivre les logs Docker (Ctrl+C pour quitter)
+	docker compose logs -f
+
+ps: ## État des conteneurs Docker
+	docker compose ps
+
+build: ## Rebuild les images Docker sans cache
+	docker compose build --no-cache
+
+# ── Symfony / Console ─────────────────────────────────────────────────────────
+
+cc: ## Vider le cache Symfony
+	docker compose exec php bin/console cache:clear
+
+migrate: ## Exécuter les migrations Doctrine
+	docker compose exec php bin/console doctrine:migrations:migrate --no-interaction
+
+diff: ## Générer une migration Doctrine depuis les entités
+	docker compose exec php bin/console doctrine:migrations:diff
+
+about: ## Afficher les infos Symfony / PHP
+	docker compose exec php bin/console about
+
+sf: ## Commande console libre  —  usage : make sf c="cache:clear"
+	docker compose exec php bin/console $(c)
+
+# ── Composer ──────────────────────────────────────────────────────────────────
+
+install: ## Installer les dépendances Composer
+	docker compose exec php composer install
+
+update: ## Mettre à jour les dépendances Composer
+	docker compose exec php composer update
+
+require: ## Ajouter une dépendance  —  usage : make require p="vendor/package"
+	docker compose exec php composer require $(p)
+
+require-dev: ## Ajouter une dépendance dev  —  usage : make require-dev p="vendor/package"
+	docker compose exec php composer require --dev $(p)
+
+# ── Frontend / npm (conteneur node) ──────────────────────────────────────────
+
+npm-install: ## Installer les dépendances npm
+	docker compose exec node npm install
+
+lint: ## Lancer ESLint sur le frontend
+	docker compose exec node npm run lint
+
+npm-add: ## Ajouter une dépendance npm  —  usage : make npm-add p="package"
+	docker compose exec node npm install $(p)
+
+npm-add-dev: ## Ajouter une dépendance npm dev  —  usage : make npm-add-dev p="package"
+	docker compose exec node npm install --save-dev $(p)
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+test: test-back test-front ## Lancer tous les tests (backend puis frontend)
+
+test-back: ## Lancer les tests PHPUnit
+	docker compose exec php bin/phpunit
+
+test-front: ## Lancer les tests Vitest (exécution unique)
+	docker compose exec node npm run test -- --run
+
+test-e2e: ## Lancer les tests Playwright E2E
+	docker compose exec node npm run test:e2e
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+
+setup: ## Initialiser l'environnement (première installation)
+	@if [ ! -f .env ]; then \
+		cp .env.example .env; \
+		echo ""; \
+		echo "  .env créé depuis .env.example."; \
+		echo "  Renseigne les valeurs puis relance : make setup"; \
+		echo ""; \
+		exit 1; \
+	fi
+	bash devops/generate-jwt-keys.sh
+	docker compose up -d
+
+jwt: ## Générer les clés JWT RS256
+	bash devops/generate-jwt-keys.sh
+
+# ── Help ──────────────────────────────────────────────────────────────────────
+
+help: ## Afficher cette aide
+	@echo ""
+	@echo "  money-manager — commandes disponibles"
+	@echo ""
+	@grep -E '^[a-zA-Z0-9_-]+:.*##' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*##"}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+
+.PHONY: up down restart logs ps build \
+        cc migrate diff about sf \
+        install update require require-dev \
+        npm-install lint npm-add npm-add-dev \
+        test test-back test-front test-e2e \
+        setup jwt help

--- a/README.md
+++ b/README.md
@@ -11,34 +11,22 @@ Application personnelle de gestion financière.
 ### Prérequis
 
 - Docker Desktop ≥ 4.24 (Docker Compose v2.20+)
+- `make` (inclus sur macOS et Linux)
 - `openssl` disponible en ligne de commande
 
-### 1. Configuration
+### Installation
 
 ```bash
-cp .env.example .env
-# Renseigner les mots de passe dans .env (remplacer tous les "change_me")
+make setup
 ```
 
-### 2. Clés JWT
-
-```bash
-bash devops/generate-jwt-keys.sh
-# Génère backend/config/jwt/private.pem et public.pem
-# Écrit JWT_PASSPHRASE dans .env automatiquement
-```
-
-### 3. Démarrage
-
-```bash
-docker compose up -d
-```
+`make setup` copie `.env.example` vers `.env` (si absent), génère les clés JWT RS256, puis démarre tous les services Docker. Si `.env` vient d'être créé, renseigne les mots de passe (remplace les `change_me`), puis relance `make setup`.
 
 ### Services accessibles en dev
 
 | Service | URL | Credentials |
 |---|---|---|
-| API Backend | http://localhost | — |
+| API Backend | http://localhost:8080 | — |
 | Frontend (Vite) | http://localhost:5173 | — |
 | RabbitMQ Management | http://localhost:15672 | `RABBITMQ_USER` / `RABBITMQ_PASSWORD` |
 | Mailpit (emails) | http://localhost:8025 | — |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -13,7 +13,7 @@ Les ⏸ gates sont des points d'arrêt où l'utilisateur doit valider avant que 
 | ⏸ Gate 5 | US | QA | Documentaliste + DevOps |
 | ⏸ Gate TS1 | TS-Technique, TS-Transverse | Architecte (rédaction TS) | Backend/Frontend Developer |
 | ⏸ Gate TSI1 | TS-Infra | DevOps (rédaction TS) | DevOps (implémentation) |
-| ⏸ Gate TS2 / TSI2 | TS-Technique / TS-Infra | Security & Code Reviewer | QA / merge |
+| ⏸ Gate TS2 / TSI2 | TS-Technique / TS-Infra | Security & Code Reviewer | QA / Documentaliste (si applicable) / merge |
 | ⏸ Gate TS3 | TS-Technique | QA | DevOps |
 
 ## Flux US (User Story)
@@ -100,6 +100,10 @@ Security & Code Reviewer
 ⏸ Gate TSI2 — validation utilisateur
         │
         ▼
+Documentaliste (si impact sur commandes ou config utilisateur)
+└── Mise à jour documentation
+        │
+        ▼
       merge
 ```
 
@@ -145,3 +149,4 @@ Le PO choisit l'initiateur (Architecte ou DevOps), puis le flux TS-Technique s'a
 - L'UI/UX Designer n'intervient jamais dans un flux TS
 - Le QA est allégé sur les TS : tests de non-régression uniquement, pas de validation des critères d'acceptance métier
 - Une TS-Infra sans impact sur le code applicatif ne nécessite pas de passage QA
+- Une TS-Infra avec impact sur les commandes ou la configuration utilisateur déclenche un passage Documentaliste après Gate TSI2


### PR DESCRIPTION
## Résumé

Ajout d'un `Makefile` à la racine du projet centralisant les commandes les plus fréquentes pour Docker, Symfony, Composer, npm et les tests.

## Targets (25)

| Groupe | Targets |
|---|---|
| Docker | `up`, `down`, `restart`, `logs`, `ps`, `build` |
| Symfony | `cc`, `migrate`, `diff`, `about`, `sf c="..."` |
| Composer | `install`, `update`, `require p="..."`, `require-dev p="..."` |
| npm (node) | `npm-install`, `lint`, `npm-add p="..."`, `npm-add-dev p="..."` |
| Tests | `test`, `test-back`, `test-front`, `test-e2e` |
| Setup | `setup`, `jwt` |
| Aide | `help` |

## Points notables

- `make help` — liste colorée auto-générée depuis les commentaires `##`
- `make sf c="..."` — commande console Symfony libre
- `make setup` — copie `.env.example` si `.env` absent et guide l'utilisateur, génère les clés JWT puis lance Docker
- Toutes les commandes npm/node passent par le conteneur `node` (pas d'exécution locale)
- Closes #13

## Validation

- `make help` — 25 targets listées ✅
- `make ps` — état des conteneurs ✅
- `make sf c="about"` — Symfony 7.4.8 / PHP 8.5.5 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)